### PR TITLE
Update app to run on box ip

### DIFF
--- a/api/sentinel_api_app.py
+++ b/api/sentinel_api_app.py
@@ -76,5 +76,5 @@ if __name__ == '__main__':
     logging.basicConfig(format=logging_format, handlers=[handler], level=logging.DEBUG)
 
     # Start the server
-    app.run(debug=True)
+    app.run(host='0.0.0.0', debug=True)
 


### PR DESCRIPTION
This updates the host flag in `app.run` to use the box's actual ip address instead of the default local host.