### PR TITLE
Datetime updates

### DIFF
--- a/client/monitor.py
+++ b/client/monitor.py
@@ -1,7 +1,7 @@
-from client.util.trigger_helper import FrontDoorMonitor
+from client.util.trigger_helper import DoorMonitor
 from client.util.client_config import endpoints, gpio_pin_map, client_identifier
 
-front_door = FrontDoorMonitor(
+front_door = DoorMonitor(
     name='front_door',
     gpio_pin=gpio_pin_map.get('front_door'),
     notify_endpoint=endpoints.get('notify'),

--- a/client/util/trigger_helper.py
+++ b/client/util/trigger_helper.py
@@ -104,7 +104,7 @@ class BinaryTrigger(Trigger):
         raise NotImplementedError
 
 
-class FrontDoorMonitor(BinaryTrigger):
+class DoorMonitor(BinaryTrigger):
 
     def route_action(self):
         """

--- a/client/util/trigger_helper.py
+++ b/client/util/trigger_helper.py
@@ -78,7 +78,7 @@ class BinaryTrigger(Trigger):
         :returns: float, total seconds the trigger has been in one state or 'open'
             format is [seconds].[microseconds]
         """
-        duration = datetime.now() - self.start_time
+        duration = datetime.utcnow() - self.start_time
         return duration.total_seconds()
 
     def should_notify(self):
@@ -113,7 +113,7 @@ class FrontDoorMonitor(BinaryTrigger):
         """
         if gpio.input(self.gpio_pin) and not self.state:
             # set the start time
-            self.start_time = datetime.now()
+            self.start_time = datetime.utcnow()
 
             # Inform the end-user that the front door has been opened
             # and Log the event
@@ -151,7 +151,7 @@ class FrontDoorMonitor(BinaryTrigger):
 
         elif not gpio.input(self.gpio_pin) and self.state:
             # the trigger has been fired due to a 'close' event
-            close_time = datetime.now()
+            close_time = datetime.utcnow()
 
             # Prep the notificaiton payload
             payload = {


### PR DESCRIPTION
This updates datetime calls to use `utcnow()` instead of `now()` . The current method uses the Raspberry Pi's system default timezone. This change will standardize this so all calls and times are in UTC.

Additionally, the `FrontDoorMonitor` name was updated to `DoorMonitor`.